### PR TITLE
Update runtime to org.freedesktop.Platform 19.08

### DIFF
--- a/de.billardgl.Billardgl.json
+++ b/de.billardgl.Billardgl.json
@@ -2,7 +2,7 @@
     "app-id": "de.billardgl.Billardgl",
     "runtime": "org.freedesktop.Platform",
     "sdk": "org.freedesktop.Sdk",
-    "runtime-version": "18.08",
+    "runtime-version": "19.08",
     "command": "billard-gl",
     "separate-locales": false,
     "cleanup": [ "/include", "/lib/*.a", "/lib/*.la", "/lib/pkgconfig" ],
@@ -12,7 +12,7 @@
         "--device=dri"
     ],
     "modules": [
-        "shared-modules/glu/glu-9.0.0.json",
+        "shared-modules/glu/glu-9.json",
         {
             "name": "freeglut",
             "buildsystem": "cmake-ninja",


### PR DESCRIPTION
This works nicely using 19.08, with one change to get freeglut building again. This gives us a newer version of Mesa which will improve hardware support - particularly for Intel Ice Lake.